### PR TITLE
Feat/request#3

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,61 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="ComposePreviewDimensionRespectsLimit" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="ComposePreviewMustBeTopLevelFunction" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="ComposePreviewNeedsComposableAnnotation" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="ComposePreviewNotSupportedInUnitTestFiles" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="GlancePreviewDimensionRespectsLimit" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="GlancePreviewMustBeTopLevelFunction" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="GlancePreviewNeedsComposableAnnotation" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="GlancePreviewNotSupportedInUnitTestFiles" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewAnnotationInFunctionWithParameters" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewApiLevelMustBeValid" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewDeviceShouldUseNewSpec" enabled="true" level="WEAK WARNING" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewFontScaleMustBeGreaterThanZero" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewMultipleParameterProviders" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewParameterProviderOnFirstParameter" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewPickerAnnotation" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+  </profile>
+</component>

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
+    id("kotlin-parcelize")
 }
 
 android {

--- a/app/src/main/java/com/example/commit/data/model/RequestDetailResponse.kt
+++ b/app/src/main/java/com/example/commit/data/model/RequestDetailResponse.kt
@@ -31,3 +31,9 @@ data class OptionItem(
     val label: String
 ) : Parcelable
 
+@Parcelize
+data class TimelineEvent(
+    val iconRes: Int,
+    val description: String,
+    val date: String
+): Parcelable

--- a/app/src/main/java/com/example/commit/data/model/RequestDetailResponse.kt
+++ b/app/src/main/java/com/example/commit/data/model/RequestDetailResponse.kt
@@ -1,0 +1,33 @@
+package com.example.commit.data.model
+
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+data class TimelineItem(
+    val status: String,
+    val label: String,
+    val changedAt: String
+) : Parcelable
+
+@Parcelize
+data class PaymentInfo(
+    val paidAt: String,
+    val basePrice: Int,
+    val additionalPrice: Int,
+    val totalPrice: Int,
+    val paymentMethod: String
+) : Parcelable
+
+@Parcelize
+data class FormItem(
+    val type: String,
+    val label: String,
+    val options: List<OptionItem> = emptyList()
+) : Parcelable
+
+@Parcelize
+data class OptionItem(
+    val label: String
+) : Parcelable
+

--- a/app/src/main/java/com/example/commit/data/model/RequestItem.kt
+++ b/app/src/main/java/com/example/commit/data/model/RequestItem.kt
@@ -1,10 +1,15 @@
 package com.example.commit.data.model
 
+import kotlinx.parcelize.Parcelize
+import android.os.Parcelable
+
+@Parcelize
 data class Artist(
     val id: Int,
     val nickname: String
-)
+) : Parcelable
 
+@Parcelize
 data class RequestItem(
     val requestId: Int,
     val status: String,
@@ -12,4 +17,4 @@ data class RequestItem(
     val price: Int,
     val thumbnailImage: String,
     val artist: Artist
-)
+) : Parcelable

--- a/app/src/main/java/com/example/commit/ui/request/FragmentRequestDetail.kt
+++ b/app/src/main/java/com/example/commit/ui/request/FragmentRequestDetail.kt
@@ -23,6 +23,8 @@ import com.example.commit.data.model.*
 import com.example.commit.ui.request.components.RequestDetailItem
 import com.example.commit.ui.request.components.RequestDetailSectionList
 import com.example.commit.ui.request.notoSansKR
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 
 class FragmentRequestDetail : Fragment() {
     override fun onCreateView(
@@ -68,6 +70,7 @@ fun RequestDetailScreen(
         modifier = Modifier
             .fillMaxSize()
             .background(Color(0xFFE8E8E8))
+            .verticalScroll(rememberScrollState())
     ) {
         // 상단 타이틀 바
         Box(

--- a/app/src/main/java/com/example/commit/ui/request/FragmentRequestDetail.kt
+++ b/app/src/main/java/com/example/commit/ui/request/FragmentRequestDetail.kt
@@ -1,0 +1,67 @@
+package com.example.commit.ui.request
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.unit.dp
+import androidx.fragment.app.Fragment
+import com.example.commit.data.model.*
+import com.example.commit.ui.request.components.RequestDetailSectionList
+
+class FragmentRequestDetail : Fragment() {
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        return ComposeView(requireContext()).apply {
+            setContent {
+                val timeline = arguments?.getParcelableArrayList<TimelineItem>("timeline") ?: emptyList()
+                val paymentInfo = arguments?.getParcelable<PaymentInfo>("paymentInfo")
+                val formSchema = arguments?.getParcelableArrayList<FormItem>("formSchema") ?: emptyList()
+                val formAnswer = arguments?.getSerializable("formAnswer") as? Map<String, Any> ?: emptyMap()
+
+                if (paymentInfo != null) {
+                    RequestDetailContent(
+                        timeline = timeline,
+                        paymentInfo = paymentInfo,
+                        formSchema = formSchema,
+                        formAnswer = formAnswer
+                    )
+                } else {
+                    Text("데이터를 불러오지 못했습니다.")
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun RequestDetailContent(
+    timeline: List<TimelineItem>,
+    paymentInfo: PaymentInfo,
+    formSchema: List<FormItem>,
+    formAnswer: Map<String, Any>
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Color(0xFFE8E8E8))
+            .padding(16.dp)
+    ) {
+        RequestDetailSectionList(
+            timeline = timeline,
+            paymentInfo = paymentInfo,
+            formSchema = formSchema,
+            formAnswer = formAnswer
+        )
+    }
+}

--- a/app/src/main/java/com/example/commit/ui/request/FragmentRequestDetail.kt
+++ b/app/src/main/java/com/example/commit/ui/request/FragmentRequestDetail.kt
@@ -4,17 +4,25 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.fragment.app.Fragment
+import com.example.commit.R
 import com.example.commit.data.model.*
+import com.example.commit.ui.request.components.RequestDetailItem
 import com.example.commit.ui.request.components.RequestDetailSectionList
+import com.example.commit.ui.request.notoSansKR
 
 class FragmentRequestDetail : Fragment() {
     override fun onCreateView(
@@ -24,17 +32,20 @@ class FragmentRequestDetail : Fragment() {
     ): View {
         return ComposeView(requireContext()).apply {
             setContent {
+                val item = arguments?.getParcelable<RequestItem>("requestItem")
                 val timeline = arguments?.getParcelableArrayList<TimelineItem>("timeline") ?: emptyList()
                 val paymentInfo = arguments?.getParcelable<PaymentInfo>("paymentInfo")
                 val formSchema = arguments?.getParcelableArrayList<FormItem>("formSchema") ?: emptyList()
                 val formAnswer = arguments?.getSerializable("formAnswer") as? Map<String, Any> ?: emptyMap()
 
-                if (paymentInfo != null) {
-                    RequestDetailContent(
+                if (item != null && paymentInfo != null) {
+                    RequestDetailScreen(
+                        item = item,
                         timeline = timeline,
                         paymentInfo = paymentInfo,
                         formSchema = formSchema,
-                        formAnswer = formAnswer
+                        formAnswer = formAnswer,
+                        onBackClick = { requireActivity().onBackPressedDispatcher.onBackPressed() }
                     )
                 } else {
                     Text("데이터를 불러오지 못했습니다.")
@@ -45,23 +56,59 @@ class FragmentRequestDetail : Fragment() {
 }
 
 @Composable
-fun RequestDetailContent(
+fun RequestDetailScreen(
+    item: RequestItem,
     timeline: List<TimelineItem>,
     paymentInfo: PaymentInfo,
     formSchema: List<FormItem>,
-    formAnswer: Map<String, Any>
+    formAnswer: Map<String, Any>,
+    onBackClick: () -> Unit
 ) {
     Column(
         modifier = Modifier
             .fillMaxSize()
             .background(Color(0xFFE8E8E8))
-            .padding(16.dp)
     ) {
-        RequestDetailSectionList(
-            timeline = timeline,
-            paymentInfo = paymentInfo,
-            formSchema = formSchema,
-            formAnswer = formAnswer
-        )
+        // 상단 타이틀 바
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(100.dp)
+                .background(Color.White)
+        ) {
+            // 왼쪽 아이콘
+            Image(
+                painter = painterResource(id = R.drawable.ic_left_vector),
+                contentDescription = "뒤로가기",
+                modifier = Modifier
+                    .align(Alignment.CenterStart)
+                    .padding(start = 16.dp)
+                    .size(24.dp)
+                    .clickable { onBackClick() }
+            )
+
+            // 가운데 텍스트
+            Text(
+                text = "상세정보",
+                fontSize = 20.sp,
+                fontWeight = androidx.compose.ui.text.font.FontWeight.SemiBold,
+                fontFamily = notoSansKR,
+                color = Color.Black,
+                modifier = Modifier.align(Alignment.Center)
+            )
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        Column(modifier = Modifier.padding(horizontal = 16.dp)) {
+            RequestDetailItem(item = item)
+            Spacer(modifier = Modifier.height(16.dp))
+            RequestDetailSectionList(
+                timeline = timeline,
+                paymentInfo = paymentInfo,
+                formSchema = formSchema,
+                formAnswer = formAnswer
+            )
+        }
     }
 }

--- a/app/src/main/java/com/example/commit/ui/request/components/ExpandableSection.kt
+++ b/app/src/main/java/com/example/commit/ui/request/components/ExpandableSection.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.example.commit.R
 import com.example.commit.data.model.*
+import com.example.commit.ui.request.notoSansKR
 
 @Composable
 fun RequestDetailSectionList(
@@ -41,9 +42,7 @@ fun RequestDetailSectionList(
             expanded = isTimelineExpanded,
             onToggle = { isTimelineExpanded = !isTimelineExpanded }
         ) {
-            timeline.forEach { item ->
-                Text("${item.changedAt}: ${item.label}", fontSize = 14.sp, modifier = Modifier.padding(4.dp))
-            }
+            TimelineSection(events = timeline.map { it.toEvent() })
         }
 
         ExpandableItem(
@@ -128,7 +127,6 @@ fun RequestDetailSectionList(
             }
         }
 
-
         ExpandableItem(
             title = "신청서 보기",
             expanded = isFormExpanded,
@@ -138,7 +136,7 @@ fun RequestDetailSectionList(
                 formSchema = formSchema,
                 formAnswer = formAnswer
             )
-    }
+        }
     }
 }
 

--- a/app/src/main/java/com/example/commit/ui/request/components/ExpandableSection.kt
+++ b/app/src/main/java/com/example/commit/ui/request/components/ExpandableSection.kt
@@ -51,28 +51,94 @@ fun RequestDetailSectionList(
             expanded = isPaymentExpanded,
             onToggle = { isPaymentExpanded = !isPaymentExpanded }
         ) {
-            Text("결제일: ${paymentInfo.paidAt}")
-            Text("결제수단: ${paymentInfo.paymentMethod}")
-            Text("기본 금액: ${paymentInfo.basePrice}P")
-            Text("추가 금액: ${paymentInfo.additionalPrice}P")
-            Text("총 결제 금액: ${paymentInfo.totalPrice}P")
+            Column(modifier = Modifier.fillMaxWidth()) {
+
+                // 결제일시 + 상태
+                Text(
+                    text = "${paymentInfo.paidAt} 결제완료",
+                    fontSize = 12.sp,
+                    fontFamily = notoSansKR,
+                    color = Color.Gray
+                )
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                // 기본 금액
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween
+                ) {
+                    Text(
+                        text = "기본 금액",
+                        fontSize = 14.sp,
+                        fontFamily = notoSansKR,
+                        color = Color.Gray
+                    )
+                    Text(
+                        text = "${"%,d".format(paymentInfo.basePrice)}P",
+                        fontSize = 14.sp,
+                        fontFamily = notoSansKR,
+                        color = Color.Black
+                    )
+                }
+
+                Spacer(modifier = Modifier.height(8.dp))
+
+                // 추가 금액
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween
+                ) {
+                    Text(
+                        text = "추가 금액",
+                        fontSize = 14.sp,
+                        fontFamily = notoSansKR,
+                        color = Color.Gray
+                    )
+                    Text(
+                        text = "${"%,d".format(paymentInfo.additionalPrice)}P",
+                        fontSize = 14.sp,
+                        fontFamily = notoSansKR,
+                        color = Color.Black
+                    )
+                }
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                // 총 결제 금액
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween
+                ) {
+                    Text(
+                        text = "총 결제 금액",
+                        fontSize = 16.sp,
+                        fontFamily = notoSansKR,
+                        fontWeight = FontWeight.Bold,
+                        color = Color.Black
+                    )
+                    Text(
+                        text = "${"%,d".format(paymentInfo.totalPrice)}P",
+                        fontSize = 16.sp,
+                        fontFamily = notoSansKR,
+                        fontWeight = FontWeight.Bold,
+                        color = Color.Black
+                    )
+                }
+            }
         }
+
 
         ExpandableItem(
             title = "신청서 보기",
             expanded = isFormExpanded,
             onToggle = { isFormExpanded = !isFormExpanded }
         ) {
-            formSchema.forEach { item ->
-                val answer = formAnswer[item.label]
-                val answerText = when (answer) {
-                    is List<*> -> answer.joinToString(", ")
-                    is String -> answer
-                    else -> "응답 없음"
-                }
-                Text("${item.label}: $answerText", fontSize = 14.sp, modifier = Modifier.padding(4.dp))
-            }
-        }
+            FormAnswerSection(
+                formSchema = formSchema,
+                formAnswer = formAnswer
+            )
+    }
     }
 }
 

--- a/app/src/main/java/com/example/commit/ui/request/components/ExpandableSection.kt
+++ b/app/src/main/java/com/example/commit/ui/request/components/ExpandableSection.kt
@@ -1,0 +1,120 @@
+package com.example.commit.ui.request.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Icon
+import androidx.compose.material.Text
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.example.commit.R
+import com.example.commit.data.model.*
+
+@Composable
+fun RequestDetailSectionList(
+    timeline: List<TimelineItem>,
+    paymentInfo: PaymentInfo,
+    formSchema: List<FormItem>,
+    formAnswer: Map<String, Any>
+) {
+    var isTimelineExpanded by remember { mutableStateOf(false) }
+    var isPaymentExpanded by remember { mutableStateOf(false) }
+    var isFormExpanded by remember { mutableStateOf(false) }
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(12.dp))
+            .background(Color.White)
+            .padding(8.dp)
+    ) {
+        ExpandableItem(
+            title = "타임라인",
+            expanded = isTimelineExpanded,
+            onToggle = { isTimelineExpanded = !isTimelineExpanded }
+        ) {
+            timeline.forEach { item ->
+                Text("${item.changedAt}: ${item.label}", fontSize = 14.sp, modifier = Modifier.padding(4.dp))
+            }
+        }
+
+        ExpandableItem(
+            title = "결제정보",
+            expanded = isPaymentExpanded,
+            onToggle = { isPaymentExpanded = !isPaymentExpanded }
+        ) {
+            Text("결제일: ${paymentInfo.paidAt}")
+            Text("결제수단: ${paymentInfo.paymentMethod}")
+            Text("기본 금액: ${paymentInfo.basePrice}P")
+            Text("추가 금액: ${paymentInfo.additionalPrice}P")
+            Text("총 결제 금액: ${paymentInfo.totalPrice}P")
+        }
+
+        ExpandableItem(
+            title = "신청서 보기",
+            expanded = isFormExpanded,
+            onToggle = { isFormExpanded = !isFormExpanded }
+        ) {
+            formSchema.forEach { item ->
+                val answer = formAnswer[item.label]
+                val answerText = when (answer) {
+                    is List<*> -> answer.joinToString(", ")
+                    is String -> answer
+                    else -> "응답 없음"
+                }
+                Text("${item.label}: $answerText", fontSize = 14.sp, modifier = Modifier.padding(4.dp))
+            }
+        }
+    }
+}
+
+@Composable
+fun ExpandableItem(
+    title: String,
+    expanded: Boolean,
+    onToggle: () -> Unit,
+    content: @Composable ColumnScope.() -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { onToggle() }
+            .padding(horizontal = 12.dp, vertical = 10.dp)
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Text(
+                text = title,
+                fontSize = 15.sp,
+                fontWeight = FontWeight.Medium,
+                color = Color.Black
+            )
+            Spacer(modifier = Modifier.weight(1f))
+            if (expanded) {
+                Icon(
+                    painter = painterResource(id = R.drawable.ic_up_vector),
+                    contentDescription = null,
+                    modifier = Modifier.size(14.dp)
+                )
+            } else {
+                Icon(
+                    painter = painterResource(id = R.drawable.ic_under_vector),
+                    contentDescription = null,
+                    modifier = Modifier.size(15.dp)
+                )
+            }
+        }
+
+        if (expanded) {
+            Spacer(modifier = Modifier.height(12.dp))
+            content()
+        }
+    }
+}

--- a/app/src/main/java/com/example/commit/ui/request/components/FormAnswerSection.kt
+++ b/app/src/main/java/com/example/commit/ui/request/components/FormAnswerSection.kt
@@ -1,0 +1,152 @@
+package com.example.commit.ui.request.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.Font
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import coil.compose.AsyncImage
+import com.example.commit.R
+import com.example.commit.data.model.FormItem
+import com.example.commit.ui.request.notoSansKR
+
+val notoSansKR = FontFamily(
+    Font(R.font.notosanskr_regular, FontWeight.Normal),
+    Font(R.font.notosanskr_medium, FontWeight.Medium),
+    Font(R.font.notosanskr_semibold, FontWeight.SemiBold),
+    Font(R.font.notosanskr_bold, FontWeight.Bold)
+)
+
+@Composable
+fun FormAnswerSection(
+    formSchema: List<FormItem>,
+    formAnswer: Map<String, Any>
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(Color.White)
+            .padding(16.dp)
+    ) {
+        Text(
+            text = "신청 폼",
+            fontSize = 14.sp,
+            fontWeight = FontWeight.SemiBold,
+            fontFamily = notoSansKR,
+            color = Color.Black,
+            modifier = Modifier.padding(bottom = 8.dp)
+        )
+
+        formSchema.forEachIndexed { index, item ->
+            val answer = formAnswer[item.label]
+            val answerText = when (answer) {
+                is List<*> -> answer.joinToString(", ")
+                is String -> answer
+                else -> "응답 없음"
+            }
+
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = 4.dp)
+                    .clip(RoundedCornerShape(8.dp))
+                    .background(Color(0xFFF5F5F5))
+                    .border(1.dp, Color(0xFFE0E0E0), RoundedCornerShape(8.dp))
+                    .padding(12.dp)
+            ) {
+                Column {
+                    Text(
+                        text = "${index + 1}. ${item.label}",
+                        fontSize = 14.sp,
+                        fontWeight = FontWeight.Bold,
+                        fontFamily = notoSansKR,
+                        color = Color.Black
+                    )
+                    Spacer(modifier = Modifier.height(4.dp))
+                    Text(
+                        text = answerText.toString(),
+                        fontSize = 13.sp,
+                        color = Color.DarkGray,
+                        fontFamily = notoSansKR
+                    )
+                }
+            }
+        }
+
+        // 신청 내용 + 이미지
+        val note = formAnswer["신청 내용"] as? String
+        val imageUrl = formAnswer["이미지"] as? String
+
+        if (!note.isNullOrBlank() || !imageUrl.isNullOrBlank()) {
+            Spacer(modifier = Modifier.height(16.dp))
+
+            Text(
+                text = "신청 내용",
+                fontSize = 14.sp,
+                fontWeight = FontWeight.SemiBold,
+                fontFamily = notoSansKR,
+                color = Color.Black,
+                modifier = Modifier.padding(bottom = 8.dp)
+            )
+
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clip(RoundedCornerShape(8.dp))
+                    .padding(12.dp)
+            ) {
+                if (!note.isNullOrBlank()) {
+                    Text(
+                        text = note,
+                        fontSize = 13.sp,
+                        color = Color.Black,
+                        fontFamily = notoSansKR
+                    )
+                }
+
+                if (!imageUrl.isNullOrBlank()) {
+                    Spacer(modifier = Modifier.height(12.dp))
+                    AsyncImage(
+                        model = imageUrl,
+                        contentDescription = "첨부 이미지",
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(160.dp)
+                            .clip(RoundedCornerShape(4.dp))
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun PreviewFormAnswerSection() {
+    val dummyFormSchema = listOf(
+        FormItem(type = "radio", label = "당일마감 옵션", options = listOf()),
+        FormItem(type = "radio", label = "신청 부위", options = listOf()),
+        FormItem(type = "checkbox", label = "프로필 공사항 확인해주세요!", options = listOf())
+    )
+
+    val dummyFormAnswer = mapOf(
+        "당일마감 옵션" to "O",
+        "신청 부위" to "전신",
+        "프로필 공사항 확인해주세요!" to listOf("알겠습니다"),
+        "신청 내용" to "귀엽게 그려주세요!",
+        "이미지" to "https://i.namu.wiki/i/eo5nbfHMQNRzJv3_f-qY6sDXo3aZqj8DPTk09XIEAK9Ugh6J53ZYXxhFjZUBuPj_aqFaz6XWZ5eUHRoWKLHfRA.webp"
+    )
+
+    FormAnswerSection(formSchema = dummyFormSchema, formAnswer = dummyFormAnswer)
+}

--- a/app/src/main/java/com/example/commit/ui/request/components/RequestCard.kt
+++ b/app/src/main/java/com/example/commit/ui/request/components/RequestCard.kt
@@ -22,9 +22,11 @@ import com.example.commit.R
 import com.example.commit.data.model.Artist
 import com.example.commit.data.model.RequestItem
 import com.example.commit.ui.request.notoSansKR
+import androidx.compose.foundation.clickable
+
 
 @Composable
-fun RequestCard(item: RequestItem) {
+fun RequestCard(item: RequestItem, onClick: () -> Unit) {
     val isDone = item.status == "DONE"
     val isInProgress = !isDone
 
@@ -35,10 +37,9 @@ fun RequestCard(item: RequestItem) {
         modifier = Modifier
             .fillMaxWidth()
             .padding(vertical = 8.dp)
+            .clickable { onClick() }
     ) {
         Column(modifier = Modifier.padding(16.dp)) {
-
-            // 🔹 진행 상태 + 오른쪽 아이콘
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 verticalAlignment = Alignment.CenterVertically,
@@ -94,25 +95,22 @@ fun RequestCard(item: RequestItem) {
                         text = "${item.price}P",
                         fontSize = 14.sp,
                         color = Color(0xFF4D4D4D),
-                        fontFamily = notoSansKR,
-                        fontWeight = FontWeight.Normal
+                        fontFamily = notoSansKR
                     )
 
                     Spacer(modifier = Modifier.height(4.dp))
 
-                    // 🔹 문의하기 + 아이콘 한 줄 정렬
                     Row(verticalAlignment = Alignment.CenterVertically) {
                         Text(
                             text = "작가에게 문의하기",
                             fontSize = 12.sp,
                             fontFamily = notoSansKR,
-                            fontWeight = FontWeight.Normal,
                             color = Color(0xFF4D4D4D)
                         )
                         Spacer(modifier = Modifier.width(2.dp))
                         Icon(
                             painter = painterResource(id = R.drawable.artist_vector),
-                            contentDescription = "화살표",
+                            contentDescription = "문의 화살표",
                             tint = Color(0xFF4D4D4D),
                             modifier = Modifier.size(12.dp)
                         )
@@ -180,5 +178,5 @@ fun RequestCardPreview() {
         thumbnailImage = "https://via.placeholder.com/150",
         artist = Artist(1, "사과")
     )
-    RequestCard(item = sampleItem)
+    RequestCard(item = sampleItem, onClick = {})
 }

--- a/app/src/main/java/com/example/commit/ui/request/components/RequestDetailItem.kt
+++ b/app/src/main/java/com/example/commit/ui/request/components/RequestDetailItem.kt
@@ -1,0 +1,136 @@
+package com.example.commit.ui.request.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import coil.compose.AsyncImage
+import com.example.commit.R
+import com.example.commit.data.model.Artist
+import com.example.commit.data.model.RequestItem
+
+@Composable
+fun RequestDetailItem(item: RequestItem) {
+    val isInProgress = item.status == "IN_PROGRESS" || item.status == "ACCEPTED"
+    val statusText = if (isInProgress) "진행 중" else "거래 완료"
+    val statusColor = if (isInProgress) Color(0xFF17D5C6) else Color.Black
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(12.dp))
+            .background(Color.White)
+            .padding(16.dp)
+    ) {
+        // 상태 + 날짜
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Text(
+                text = statusText,
+                fontSize = 14.sp,
+                fontWeight = FontWeight.Bold,
+                color = statusColor
+            )
+            Spacer(modifier = Modifier.width(8.dp))
+            Text(
+                text = "25.05.01(목) 작업 완료", // TODO: 실제 날짜 반영
+                fontSize = 12.sp,
+                color = Color.Gray
+            )
+        }
+
+        Spacer(modifier = Modifier.height(12.dp))
+
+        // 썸네일 + 정보
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            AsyncImage(
+                model = item.thumbnailImage,
+                contentDescription = "Thumbnail",
+                contentScale = ContentScale.Crop,
+                modifier = Modifier
+                    .size(80.dp)
+                    .clip(RoundedCornerShape(8.dp))
+                    .background(Color(0xFFE8E8E8)),
+                error = painterResource(id = R.drawable.ic_default_image),
+                fallback = painterResource(id = R.drawable.ic_default_image)
+            )
+            Spacer(modifier = Modifier.width(12.dp))
+            Column {
+                Text("${item.artist.nickname}", fontSize = 12.sp, color = Color.Gray)
+                Text(
+                    text = item.title,
+                    fontSize = 14.sp,
+                    fontWeight = FontWeight.Bold,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+                Text("${item.price}P", fontSize = 14.sp, fontWeight = FontWeight.Bold)
+            }
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        // 작업물 확인 버튼
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(40.dp)
+                .clip(RoundedCornerShape(8.dp))
+                .background(if (isInProgress) Color(0xFFE8E8E8) else Color.Black)
+                .then(if (!isInProgress) Modifier.clickable { /* TODO: 클릭 동작 */ } else Modifier),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(
+                text = "작업물 확인",
+                color = if (isInProgress) Color.Gray else Color.White,
+                fontWeight = FontWeight.Bold
+            )
+        }
+
+        Spacer(modifier = Modifier.height(12.dp))
+
+        // 하단 버튼 3개
+        Row(modifier = Modifier.fillMaxWidth()) {
+            listOf("거래완료", "후기작성", "문의하기").forEach { label ->
+                Box(
+                    modifier = Modifier
+                        .weight(1f)
+                        .height(36.dp)
+                        .padding(horizontal = 4.dp)
+                        .clip(RoundedCornerShape(8.dp))
+                        .background(Color(0xFFF0F0F0)),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Text(label, fontSize = 13.sp)
+                }
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun PreviewRequestDetailItem() {
+    val dummyItem = RequestItem(
+        requestId = 1,
+        status = "ACCEPTED",
+        title = "2인 캐릭터 세트",
+        price = 16000,
+        thumbnailImage = "",
+        artist = Artist(id = 1, nickname = "감자")
+    )
+    RequestDetailItem(item = dummyItem)
+}
+

--- a/app/src/main/java/com/example/commit/ui/request/components/RequestDetailItem.kt
+++ b/app/src/main/java/com/example/commit/ui/request/components/RequestDetailItem.kt
@@ -89,7 +89,7 @@ fun RequestDetailItem(item: RequestItem) {
                 .height(40.dp)
                 .clip(RoundedCornerShape(8.dp))
                 .background(if (isInProgress) Color(0xFFE8E8E8) else Color.Black)
-                .then(if (!isInProgress) Modifier.clickable { /* TODO: 클릭 동작 */ } else Modifier),
+                .then(if (!isInProgress) Modifier.clickable { /* TODO */ } else Modifier),
             contentAlignment = Alignment.Center
         ) {
             Text(
@@ -103,20 +103,28 @@ fun RequestDetailItem(item: RequestItem) {
 
         // 하단 버튼 3개
         Row(modifier = Modifier.fillMaxWidth()) {
-            listOf("거래완료", "후기작성", "문의하기").forEach { label ->
+            listOf("거래완료", "후기작성", "문의하기").forEachIndexed { index, label ->
+                val isFirst = index == 0
+                val disableFirst = isFirst && !isInProgress
+
+                val buttonBackground = if (disableFirst) Color(0xFFEDEDED) else Color(0xFFF0F0F0)
+                val textColor = if (disableFirst) Color(0xFFB0B0B0) else Color.Black
+
                 Box(
                     modifier = Modifier
                         .weight(1f)
                         .height(36.dp)
                         .padding(horizontal = 4.dp)
                         .clip(RoundedCornerShape(8.dp))
-                        .background(Color(0xFFF0F0F0)),
+                        .background(buttonBackground)
+                        .then(if (!disableFirst) Modifier.clickable { /* TODO: 클릭 동작 */ } else Modifier),
                     contentAlignment = Alignment.Center
                 ) {
-                    Text(label, fontSize = 13.sp)
+                    Text(label, fontSize = 13.sp, color = textColor)
                 }
             }
         }
+
     }
 }
 
@@ -125,7 +133,7 @@ fun RequestDetailItem(item: RequestItem) {
 fun PreviewRequestDetailItem() {
     val dummyItem = RequestItem(
         requestId = 1,
-        status = "ACCEPTED",
+        status = "DONE",
         title = "2인 캐릭터 세트",
         price = 16000,
         thumbnailImage = "",
@@ -133,4 +141,3 @@ fun PreviewRequestDetailItem() {
     )
     RequestDetailItem(item = dummyItem)
 }
-

--- a/app/src/main/java/com/example/commit/ui/request/components/TimelineSection.kt
+++ b/app/src/main/java/com/example/commit/ui/request/components/TimelineSection.kt
@@ -1,0 +1,104 @@
+package com.example.commit.ui.request.components
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.example.commit.R
+import com.example.commit.data.model.TimelineEvent
+import com.example.commit.data.model.TimelineItem
+import com.example.commit.ui.request.notoSansKR
+
+@Composable
+fun TimelineSection(events: List<TimelineEvent>) {
+    Column(modifier = Modifier.fillMaxWidth()) {
+        events.forEachIndexed { index, event ->
+            Row(
+                verticalAlignment = Alignment.Top,
+                modifier = Modifier.padding(start = 16.dp, bottom = 8.dp)
+            ) {
+                Column(
+                    modifier = Modifier.width(32.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    Image(
+                        painter = painterResource(id = event.iconRes),
+                        contentDescription = null,
+                        modifier = Modifier.size(20.dp)
+                    )
+                    if (index != events.lastIndex) {
+                        Box(
+                            modifier = Modifier
+                                .width(2.dp)
+                                .height(48.dp)
+                                .background(Color(0xFFEDEDED))
+                        )
+                    }
+                }
+
+                Spacer(modifier = Modifier.width(12.dp))
+
+                Column(modifier = Modifier.padding(top = 2.dp)) {
+                    Text(
+                        text = event.description,
+                        fontSize = 14.sp,
+                        fontFamily = notoSansKR,
+                        fontWeight = FontWeight.Normal,
+                        color = Color.Black
+                    )
+                    Spacer(modifier = Modifier.height(2.dp))
+                    Text(
+                        text = event.date,
+                        fontSize = 12.sp,
+                        fontFamily = notoSansKR,
+                        color = Color.Gray
+                    )
+                }
+            }
+        }
+    }
+}
+
+// 아이콘 리소스 매핑용 확장 함수
+fun TimelineItem.toEvent(): TimelineEvent {
+    val iconRes = when (status) {
+        "COMPLETED" -> R.drawable.timeline_complete
+        "CONFIRMED" -> R.drawable.timeline_confirm
+        "DELIVERED" -> R.drawable.timeline_delivery
+        "STARTED" -> R.drawable.timeline_start
+        "ACCEPTED" -> R.drawable.timeline_accept
+        else -> R.drawable.timeline_complete
+    }
+    return TimelineEvent(
+        iconRes = iconRes,
+        description = this.label,
+        date = this.changedAt
+    )
+}
+
+
+@Preview(showBackground = true)
+@Composable
+fun PreviewTimelineSection() {
+    val dummyItems = listOf(
+        TimelineItem("COMPLETED", "작업이 완료 되었어요.", "25.05.03 10:57"),
+        TimelineItem("CONFIRMED", "작업물을 확인했어요.", "25.05.03 10:44"),
+        TimelineItem("DELIVERED", "추가금 4,000P를 결제했어요.", "25.05.01 13:11"),
+        TimelineItem("DELIVERED", "작업물이 전달되었어요.", "25.05.01 12:30"),
+        TimelineItem("STARTED", "작가가 작업을 시작했어요.", "25.04.25 17:00"),
+        TimelineItem("ACCEPTED", "작가가 작업을 수락했어요.", "25.04.25 16:00")
+    )
+
+    val dummyEvents = dummyItems.map { it.toEvent() }
+
+    TimelineSection(events = dummyEvents)
+}

--- a/app/src/main/res/drawable/ic_left_vector.xml
+++ b/app/src/main/res/drawable/ic_left_vector.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="11dp"
+    android:height="20dp"
+    android:viewportWidth="11"
+    android:viewportHeight="20">
+  <path
+      android:pathData="M10.01,1L1,10L10.01,19"
+      android:strokeLineJoin="round"
+      android:strokeWidth="2"
+      android:fillColor="#00000000"
+      android:strokeColor="#494949"
+      android:strokeLineCap="round"/>
+</vector>

--- a/app/src/main/res/drawable/ic_up_vector.xml
+++ b/app/src/main/res/drawable/ic_up_vector.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="16dp"
+    android:height="9dp"
+    android:viewportWidth="16"
+    android:viewportHeight="9">
+  <path
+      android:pathData="M1,8L7.992,1L14.985,8"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1.5"
+      android:fillColor="#00000000"
+      android:strokeColor="#494949"
+      android:strokeLineCap="round"/>
+</vector>

--- a/app/src/main/res/drawable/timeline_accept.xml
+++ b/app/src/main/res/drawable/timeline_accept.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="17dp"
+    android:height="16dp"
+    android:viewportWidth="17"
+    android:viewportHeight="16">
+  <path
+      android:pathData="M8.296,8m-8,0a8,8 0,1 1,16 0a8,8 0,1 1,-16 0"
+      android:fillColor="#FF968D"/>
+</vector>

--- a/app/src/main/res/drawable/timeline_complete.xml
+++ b/app/src/main/res/drawable/timeline_complete.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="17dp"
+    android:height="16dp"
+    android:viewportWidth="17"
+    android:viewportHeight="16">
+  <path
+      android:pathData="M8.296,8m-8,0a8,8 0,1 1,16 0a8,8 0,1 1,-16 0"
+      android:fillColor="#EBB1FF"/>
+</vector>

--- a/app/src/main/res/drawable/timeline_confirm.xml
+++ b/app/src/main/res/drawable/timeline_confirm.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="17dp"
+    android:height="16dp"
+    android:viewportWidth="17"
+    android:viewportHeight="16">
+  <path
+      android:pathData="M8.296,8m-8,0a8,8 0,1 1,16 0a8,8 0,1 1,-16 0"
+      android:fillColor="#8CD0F0"/>
+</vector>

--- a/app/src/main/res/drawable/timeline_delivery.xml
+++ b/app/src/main/res/drawable/timeline_delivery.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="17dp"
+    android:height="16dp"
+    android:viewportWidth="17"
+    android:viewportHeight="16">
+  <path
+      android:pathData="M8.296,8m-8,0a8,8 0,1 1,16 0a8,8 0,1 1,-16 0"
+      android:fillColor="#C2EDA9"/>
+</vector>

--- a/app/src/main/res/drawable/timeline_start.xml
+++ b/app/src/main/res/drawable/timeline_start.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="17dp"
+    android:height="16dp"
+    android:viewportWidth="17"
+    android:viewportHeight="16">
+  <path
+      android:pathData="M8.296,8m-8,0a8,8 0,1 1,16 0a8,8 0,1 1,-16 0"
+      android:fillColor="#FFE186"/>
+</vector>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -37,3 +37,4 @@ activity-compose = { module = "androidx.activity:activity-compose", version = "1
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
+


### PR DESCRIPTION
## 📌 작업 내용
- 해당 카드뷰 작성
- 결제정보, 신청서 보기 구현 완료
- RequestDetailScreen 상단에 뒤로가기 버튼 추가
- 뒤로가기 클릭 시 FragmentRequest로 이동 (`onBackPressedDispatcher` 사용)
- 타임라인 섹션을 `TimelineSection()` 컴포저블로 개선
- TimelineItem → TimelineEvent 매핑 함수(`toEvent`) 적용

## 🔍 작업 목적
- 상세 페이지 내 유저의 직관적인 뒤로가기 동선 제공
- 타임라인을 텍스트 나열 대신 아이콘 포함된 UI로 개선

## ✅ 체크리스트
- [ ] 코드 리뷰 완료
- [ ] 빌드 성공
- [ ] 포맷 검사 완료

## 📝 참고 사항
- 현재 커미션 흐름은 작가가 `작업물 전달` 버튼을 누르기 전 단계까지만 구현되어 있음
- 이후 상태(작업물 확인, 거래완료 등)는 추후에 확장 예정

