### PR TITLE
Feat/chat api#80

### DIFF
--- a/app/src/main/java/com/example/commit/activity/FormCheckActivity.kt
+++ b/app/src/main/java/com/example/commit/activity/FormCheckActivity.kt
@@ -28,6 +28,7 @@ class FormCheckActivity : ComponentActivity() {
         val thumbnailUrl = intent.getStringExtra("thumbnailUrl") ?: ""
         val totalPrice = intent.getIntExtra("totalPrice", 0)
         val createdAt = intent.getStringExtra("createdAt") ?: ""
+        val artistProfileImage = intent.getStringExtra("artistProfileImage")
 
         val formSchemaJson = intent.getStringExtra("formSchemaJson")
         val formAnswerJson = intent.getStringExtra("formAnswerJson")
@@ -48,6 +49,7 @@ class FormCheckActivity : ComponentActivity() {
         // TopBar 등에 쓸 ChatItem / RequestItem 구성
         val chatItem = ChatItem(
             profileImageRes = R.drawable.ic_profile,
+            profileImageUrl = artistProfileImage,
             name = artistNickname,
             message = "",
             time = "",

--- a/app/src/main/java/com/example/commit/connection/RetrofitClient.kt
+++ b/app/src/main/java/com/example/commit/connection/RetrofitClient.kt
@@ -368,6 +368,8 @@ class RetrofitClient {
 
     // 채팅방 목록 DTO
     data class ChatroomItem(
+        @SerializedName("request_id") val requestId: Int?,              // ★ 요청 id
+        @SerializedName("commission_thumbnail_url") val thumbnailUrl: String?, // ★ 썸네일
         @SerializedName("chatroom_id")
         val chatroomId: String,
         @SerializedName("artist_id")

--- a/app/src/main/java/com/example/commit/data/model/entities/ChatItem.kt
+++ b/app/src/main/java/com/example/commit/data/model/entities/ChatItem.kt
@@ -6,6 +6,7 @@ import kotlinx.parcelize.Parcelize
 @Parcelize
 data class ChatItem(
     val profileImageRes: Int,  // drawable 리소스 ID (또는 URL)
+    val profileImageUrl: String?,
     val name: String,          // 사용자 이름
     val message: String,       // 최근 메시지
     val time: String,          // 보낸 시간 ("방금 전", "2시간 전", 등)

--- a/app/src/main/java/com/example/commit/fragment/FormCheckDialogFragment.kt
+++ b/app/src/main/java/com/example/commit/fragment/FormCheckDialogFragment.kt
@@ -54,6 +54,7 @@ class FormCheckDialogFragment : DialogFragment() {
                     val artistName = arguments?.getString("artistName") ?: ""
                     val formSchemaJson = arguments?.getString("formSchema") ?: "{}"
                     val formAnswerJson = arguments?.getString("formAnswer") ?: "{}"
+                    val artistProfileImage = arguments?.getString("artistProfileImage")?: ""
 
                     // JSON을 파싱하여 필요한 데이터 구조로 변환
                     val formSchema = try {
@@ -88,6 +89,7 @@ class FormCheckDialogFragment : DialogFragment() {
                     // 더미 데이터 생성 (실제로는 API에서 가져온 데이터 사용)
                     val chatItem = ChatItem(
                         profileImageRes = com.example.commit.R.drawable.ic_profile, // 기본 프로필 이미지 사용
+                        profileImageUrl = artistProfileImage,
                         name = artistName,
                         message = "",
                         time = "",

--- a/app/src/main/java/com/example/commit/fragment/FragmentChat.kt
+++ b/app/src/main/java/com/example/commit/fragment/FragmentChat.kt
@@ -64,6 +64,7 @@ class FragmentChat : Fragment() {
                             chatItemsState.value = rooms.map { room ->
                                 ChatItem(
                                     profileImageRes = R.drawable.ic_profile,
+                                    profileImageUrl = room.artistProfileImage,
                                     name = room.artistNickname,
                                     message = room.lastMessage ?: "새로운 메시지가 없습니다",
                                     time = formatTime(room.lastMessageTime),
@@ -84,6 +85,7 @@ class FragmentChat : Fragment() {
                             chatItemsState.value = rooms.map { room ->
                                 ChatItem(
                                     profileImageRes = R.drawable.ic_profile,
+                                    profileImageUrl = room.artistProfileImage,
                                     name = room.artistNickname,
                                     message = room.lastMessage ?: "새로운 메시지가 없습니다",
                                     time = formatTime(room.lastMessageTime),

--- a/app/src/main/java/com/example/commit/fragment/FragmentChat.kt
+++ b/app/src/main/java/com/example/commit/fragment/FragmentChat.kt
@@ -30,6 +30,7 @@ class FragmentChat : Fragment() {
 
     // 채팅방 목록 새로고침 콜백
     private var refreshCallback: (() -> Unit)? = null
+    
 
     override fun onResume() {
         super.onResume()
@@ -70,6 +71,7 @@ class FragmentChat : Fragment() {
                                     time = formatTime(room.lastMessageTime),
                                     isNew = room.hasUnread > 0,
                                     title = room.commissionTitle // 새 필드명
+
                                 )
                             }
                             isLoadingState.value = false
@@ -114,6 +116,9 @@ class FragmentChat : Fragment() {
                             val chatroomId = room.chatroomId.toIntOrNull() ?: -1
                             val commissionId = room.commissionId.toIntOrNull() ?: -1
                             val artistId = room.artistId.toIntOrNull() ?: -1
+                            val requestId    = room.requestId ?: -1
+                            val thumbnailUrl = room.thumbnailUrl ?: ""
+                            val profileUrl   = room.artistProfileImage
 
                             (activity as? MainActivity)?.showBottomNav(false)
 
@@ -125,6 +130,9 @@ class FragmentChat : Fragment() {
                                         "chatroomId" to chatroomId,
                                         "commissionId" to commissionId,
                                         "artistId" to artistId,
+                                        "requestId" to requestId,
+                                        "thumbnailUrl" to thumbnailUrl,
+                                        "artistProfileImage" to profileUrl,
                                         "hasSubmittedApplication" to false,
                                     )
                                 })

--- a/app/src/main/java/com/example/commit/fragment/FragmentChatDelete.kt
+++ b/app/src/main/java/com/example/commit/fragment/FragmentChatDelete.kt
@@ -16,8 +16,8 @@ import com.example.commit.activity.MainActivity
 class ChatDeleteFragment : Fragment() {
 
     private val dummyChatList = listOf(
-        ChatItem(R.drawable.ic_profile, "키르", "[결제 요청] 낙서 타임 커미션", "방금 전", true, "낙서 타입 커미션"),
-        ChatItem(R.drawable.ic_profile, "브로콜리", "[커미션 완료] 일러스트 타입", "2일 전", false, "일러스트 타입 커미션")
+        ChatItem(R.drawable.ic_profile,null, "키르", "[결제 요청] 낙서 타임 커미션", "방금 전", true, "낙서 타입 커미션"),
+        ChatItem(R.drawable.ic_profile,null, "브로콜리", "[커미션 완료] 일러스트 타입", "2일 전", false, "일러스트 타입 커미션")
     )
 
     private val selectedItems = mutableStateListOf<ChatItem>()

--- a/app/src/main/java/com/example/commit/fragment/FragmentChatDetail.kt
+++ b/app/src/main/java/com/example/commit/fragment/FragmentChatDetail.kt
@@ -46,6 +46,10 @@ class FragmentChatDetail : Fragment() {
         val chatroomId = arguments?.getInt("chatroomId", 1) ?: 1 // 기본값 1
         val artistId = arguments?.getInt("artistId", -1) ?: -1
         val artistProfileImage = arguments?.getString("artistProfileImage")
+        val requestId = arguments?.getInt("requestId", -1) ?: -1
+        val thumbnailUrl = arguments?.getString("thumbnailUrl") ?: ""
+
+
 
 
         return ComposeView(requireContext()).apply {
@@ -101,6 +105,8 @@ class FragmentChatDetail : Fragment() {
                         authorName = authorName,
                         chatroomId = chatroomId,
                         chatViewModel = chatViewModel, // ChatViewModel 전달
+                        authorProfileImageUrl = artistProfileImage, // ★
+                        commissionThumbnailUrl = thumbnailUrl,      // ★
                         onPayClick = {
                             if (isAdded && !isDetached) {
                                 parentFragmentManager.popBackStack()
@@ -135,16 +141,27 @@ class FragmentChatDetail : Fragment() {
                             )
                         }
                     }
-                    
-                    /*if (showFormCheckSheet.value) {
+
+                    /* if (showFormCheckSheet.value) {
                         FormCheckBottomSheet(
-                            chatItem = chatItem,
-                            requestItem = requestItem,
+                            chatItem = chatItem,               // profileImageUrl 포함된 chatItem 사용
+                            requestItem = RequestItem(
+                                requestId = requestId,         // ★ 전달
+                                status = "PENDING",
+                                title = chatName,
+                                price = 0,                     // 서버 값 있으면 대체
+                                thumbnailImageUrl = thumbnailUrl, // ★ 전달
+                                progressPercent = 0,
+                                createdAt = "",
+                                artist = Artist(id = artistId, nickname = authorName),
+                                commission = Commission(id = /* commissionId */ 0)
+                            ),
                             formSchema = formSchema,
                             formAnswer = formAnswer,
                             onDismiss = { showFormCheckSheet.value = false }
                         )
-                    }*/
+                    } */
+
                 }
             }
         }

--- a/app/src/main/java/com/example/commit/fragment/FragmentChatDetail.kt
+++ b/app/src/main/java/com/example/commit/fragment/FragmentChatDetail.kt
@@ -45,6 +45,7 @@ class FragmentChatDetail : Fragment() {
         val authorName = arguments?.getString("authorName") ?: "익명"
         val chatroomId = arguments?.getInt("chatroomId", 1) ?: 1 // 기본값 1
         val artistId = arguments?.getInt("artistId", -1) ?: -1
+        val artistProfileImage = arguments?.getString("artistProfileImage")
 
 
         return ComposeView(requireContext()).apply {
@@ -87,6 +88,7 @@ class FragmentChatDetail : Fragment() {
                     
                     val chatItem = ChatItem(
                         profileImageRes = R.drawable.ic_profile,
+                        profileImageUrl = artistProfileImage,
                         name = authorName,
                         message = "",
                         title = chatName,

--- a/app/src/main/java/com/example/commit/fragment/FragmentFormCheckScreen.kt
+++ b/app/src/main/java/com/example/commit/fragment/FragmentFormCheckScreen.kt
@@ -27,7 +27,9 @@ class FragmentFormCheckScreen : Fragment() {
                     val requestItemJson = arguments?.getString("requestItem")
                     val formSchemaJson = arguments?.getString("formSchema")
                     val formAnswerJson = arguments?.getString("formAnswer")
-                    
+                    val artistProfileImage = arguments?.getString("artistProfileImage")
+
+
                     val requestItem = gson.fromJson(requestItemJson, RequestItem::class.java)
                     val formSchema = gson.fromJson(formSchemaJson, Array<FormItem>::class.java).toList()
                     val formAnswer = gson.fromJson(formAnswerJson, Map::class.java) as Map<String, Any>
@@ -35,6 +37,7 @@ class FragmentFormCheckScreen : Fragment() {
                     // 임시 ChatItem 생성
                     val chatItem = ChatItem(
                         profileImageRes = com.example.commit.R.drawable.ic_profile,
+                        profileImageUrl = artistProfileImage,
                         name = "키르",
                         message = "",
                         title = requestItem.title,

--- a/app/src/main/java/com/example/commit/ui/FormCheck/FormCheckScreen.kt
+++ b/app/src/main/java/com/example/commit/ui/FormCheck/FormCheckScreen.kt
@@ -141,6 +141,7 @@ fun PreviewFormCheckScreen() {
     CommitTheme {
         val dummyChatItem = ChatItem(
             profileImageRes = R.drawable.ic_profile,
+            profileImageUrl = null,
             name = "키르",
             message = "최근 메시지",
             time = "2시간 전",

--- a/app/src/main/java/com/example/commit/ui/FormCheck/FormCheckScreen.kt
+++ b/app/src/main/java/com/example/commit/ui/FormCheck/FormCheckScreen.kt
@@ -8,10 +8,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext

--- a/app/src/main/java/com/example/commit/ui/FormCheck/FormCheckSection.kt
+++ b/app/src/main/java/com/example/commit/ui/FormCheck/FormCheckSection.kt
@@ -56,13 +56,21 @@ fun FormCheckSection(
                 .padding(12.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
-            Image(
-                painter = painterResource(id = item.profileImageRes),
-                contentDescription = "Profile",
-                modifier = Modifier
-                    .size(48.dp)
-                    .clip(CircleShape)
-            )
+            if (!item.profileImageUrl.isNullOrBlank()) {
+                // Coil
+                coil.compose.AsyncImage(
+                    model = item.profileImageUrl,
+                    contentDescription = "Profile",
+                    modifier = Modifier.size(48.dp).clip(CircleShape)
+                )
+            } else {
+                // 리소스/기본 아이콘
+                Image(
+                    painter = painterResource(id = item.profileImageRes),
+                    contentDescription = "Profile",
+                    modifier = Modifier.size(48.dp).clip(CircleShape)
+                )
+            }
             Spacer(modifier = Modifier.width(12.dp))
             Text(
                 text = item.name,

--- a/app/src/main/java/com/example/commit/ui/FormCheck/FormCheckTopBar.kt
+++ b/app/src/main/java/com/example/commit/ui/FormCheck/FormCheckTopBar.kt
@@ -114,7 +114,7 @@ fun FormCheckTopBarPreview() {
     CommitTheme {
         val dummyChatItem = ChatItem(
             profileImageRes = com.example.commit.R.drawable.ic_profile,
-
+            profileImageUrl = null,
             name = "키르",
             message = "최근 메시지",
             time = "2시간 전",

--- a/app/src/main/java/com/example/commit/ui/FormCheck/FormCheckTopBar.kt
+++ b/app/src/main/java/com/example/commit/ui/FormCheck/FormCheckTopBar.kt
@@ -114,6 +114,7 @@ fun FormCheckTopBarPreview() {
     CommitTheme {
         val dummyChatItem = ChatItem(
             profileImageRes = com.example.commit.R.drawable.ic_profile,
+
             name = "키르",
             message = "최근 메시지",
             time = "2시간 전",

--- a/app/src/main/java/com/example/commit/ui/chatlist/ChatDeleteScreen.kt
+++ b/app/src/main/java/com/example/commit/ui/chatlist/ChatDeleteScreen.kt
@@ -160,8 +160,8 @@ fun RoundedCheckbox(
 @Composable
 fun ChatDeleteScreenPreview() {
     val sampleChats = listOf(
-        ChatItem(R.drawable.ic_profile, "키르", "[결제 요청] 낙서 타임 커미션", "방금 전", true, "낙서 타입 커미션"),
-        ChatItem(R.drawable.ic_profile, "브로콜리", "[커미션 완료] 일러스트 타입", "2일 전", false, "일러스트 타입 커미션")
+        ChatItem(R.drawable.ic_profile, profileImageUrl = null, "키르", "[결제 요청] 낙서 타임 커미션", "방금 전", true, "낙서 타입 커미션"),
+        ChatItem(R.drawable.ic_profile, profileImageUrl = null, "브로콜리", "[커미션 완료] 일러스트 타입", "2일 전", false, "일러스트 타입 커미션")
     )
     val selected = remember { mutableStateListOf<ChatItem>() }
 

--- a/app/src/main/java/com/example/commit/ui/chatlist/ChatListItem.kt
+++ b/app/src/main/java/com/example/commit/ui/chatlist/ChatListItem.kt
@@ -24,13 +24,21 @@ fun ChatListItem(item: ChatItem,showNewIndicator: Boolean = true) {
             .padding(vertical = 12.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
-        Image(
-            painter = painterResource(id = item.profileImageRes),
-            contentDescription = "Profile",
-            modifier = Modifier
-                .size(48.dp)
-                .clip(CircleShape)
-        )
+        if (!item.profileImageUrl.isNullOrBlank()) {
+            // Coil
+            coil.compose.AsyncImage(
+                model = item.profileImageUrl,
+                contentDescription = "Profile",
+                modifier = Modifier.size(48.dp).clip(CircleShape)
+            )
+        } else {
+            // 리소스/기본 아이콘
+            Image(
+                painter = painterResource(id = item.profileImageRes),
+                contentDescription = "Profile",
+                modifier = Modifier.size(48.dp).clip(CircleShape)
+            )
+        }
 
         Spacer(modifier = Modifier.width(12.dp))
 

--- a/app/src/main/java/com/example/commit/ui/chatlist/ChatListScreen.kt
+++ b/app/src/main/java/com/example/commit/ui/chatlist/ChatListScreen.kt
@@ -103,6 +103,7 @@ fun ChatListScreenPreview() {
     val sampleChats = listOf(
         ChatItem(
             profileImageRes = R.drawable.ic_pf_charac2,
+            profileImageUrl = null,
             name = "키르",
             message = "[결제 요청] 낙서 타임 커미션",
             time = "방금 전",
@@ -111,6 +112,7 @@ fun ChatListScreenPreview() {
         ),
         ChatItem(
             profileImageRes = R.drawable.ic_pf_charac1,
+            profileImageUrl = null,
             name = "브로콜리",
             message = "[커미션 완료] 일러스트 타입",
             time = "2일 전",

--- a/app/src/main/java/com/example/commit/ui/chatroom/ChatRoomScreen.kt
+++ b/app/src/main/java/com/example/commit/ui/chatroom/ChatRoomScreen.kt
@@ -33,7 +33,8 @@ fun ChatRoomScreen(
     onBackClick: () -> Unit,
     onSettingClick: () -> Unit,
     onProfileClick: () -> Unit,
-    authorProfileImageUrl: String? = null,
+    authorProfileImageUrl: String? = null,     // ★ 추가
+    commissionThumbnailUrl: String? = null,
     chatViewModel: ChatViewModel = viewModel()
 ) {
     var isMenuOpen by remember { mutableStateOf(false) }
@@ -60,7 +61,9 @@ fun ChatRoomScreen(
 
         Spacer(modifier = Modifier.height(4.dp))
 
-        CommissionInfoCard(title = commissionTitle)
+        CommissionInfoCard(
+            title = commissionTitle,
+            thumbnailImageUrl = commissionThumbnailUrl)
 
         // 메시지 목록
         ChatMessageList(
@@ -80,10 +83,10 @@ fun ChatRoomScreen(
 
         // 입력창
         val context = LocalContext.current
-        LaunchedEffect(Unit) {
+        LaunchedEffect(chatroomId) {
             chatViewModel.loadCurrentUserId(context)
-            chatViewModel.setChatroomId(1)
-            chatViewModel.loadMessages(context, 1)
+            chatViewModel.setChatroomId(chatroomId)
+            chatViewModel.loadMessages(context, chatroomId)
         }
         ChatBottomSection(
             message = chatViewModel.message,

--- a/app/src/main/java/com/example/commit/ui/chatroom/ChatRoomScreen.kt
+++ b/app/src/main/java/com/example/commit/ui/chatroom/ChatRoomScreen.kt
@@ -33,6 +33,7 @@ fun ChatRoomScreen(
     onBackClick: () -> Unit,
     onSettingClick: () -> Unit,
     onProfileClick: () -> Unit,
+    authorProfileImageUrl: String? = null,
     chatViewModel: ChatViewModel = viewModel()
 ) {
     var isMenuOpen by remember { mutableStateOf(false) }

--- a/app/src/main/java/com/example/commit/ui/chatroom/CommissionInfoCard.kt
+++ b/app/src/main/java/com/example/commit/ui/chatroom/CommissionInfoCard.kt
@@ -33,12 +33,14 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import coil.compose.AsyncImage
 
 @Composable
 fun CommissionInfoCard(
     title: String = "낙서 타입 커미션",
     period: String = "작업기간 : 23시간",
-    onSeePostClick: () -> Unit = {}
+    onSeePostClick: () -> Unit = {},
+    thumbnailImageUrl: String? = null
 ) {
     Column(modifier = Modifier.fillMaxWidth()) {
 
@@ -49,6 +51,16 @@ fun CommissionInfoCard(
                 .padding(top = 16.dp, start = 28.dp, end = 28.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
+            if (!thumbnailImageUrl.isNullOrBlank()) {
+                AsyncImage(
+                    model = thumbnailImageUrl,
+                    contentDescription = "프로필 이미지",
+                    contentScale = ContentScale.Crop,
+                    modifier = Modifier
+                        .size(46.dp)
+                        .clip(RoundedCornerShape(4.dp))
+                )
+            } else {
             // 썸네일
             Image(
                 painter = painterResource(id = R.drawable.bg_thumbnail_rounded),
@@ -59,6 +71,7 @@ fun CommissionInfoCard(
                     .background(Color.LightGray), // 썸네일 배경 (임시)
                 contentScale = ContentScale.Crop
             )
+            }
 
             Spacer(modifier = Modifier.width(12.dp))
 

--- a/app/src/main/java/com/example/commit/ui/chatroom/CommissionInfoCard.kt
+++ b/app/src/main/java/com/example/commit/ui/chatroom/CommissionInfoCard.kt
@@ -38,7 +38,6 @@ import coil.compose.AsyncImage
 @Composable
 fun CommissionInfoCard(
     title: String = "낙서 타입 커미션",
-    period: String = "작업기간 : 23시간",
     onSeePostClick: () -> Unit = {},
     thumbnailImageUrl: String? = null
 ) {
@@ -124,7 +123,6 @@ fun CommissionInfoCard(
 fun PreviewCommissionInfoCard() {
     CommissionInfoCard(
         title = "낙서 타입 커미션",
-        period = "작업기간 : 23시간",
         onSeePostClick = { println("글보기 버튼 클릭됨") }
     )
 }

--- a/app/src/main/java/com/example/commit/util/ChatMessageMapper.kt
+++ b/app/src/main/java/com/example/commit/util/ChatMessageMapper.kt
@@ -7,6 +7,7 @@ import java.util.*
 
 fun chatMessageToChatItem(
     lastMessage: ChatMessage,
+    profileImageUrl: String?,
     profileImageRes: Int,
     name: String,
     isNew: Boolean,
@@ -14,6 +15,7 @@ fun chatMessageToChatItem(
 ): ChatItem {
     return ChatItem(
         profileImageRes = profileImageRes,
+        profileImageUrl = profileImageUrl,
         name = name,
         message = lastMessage.content,
         time = formatRelativeTime(lastMessage.timestamp),


### PR DESCRIPTION
📌 작업 내용

- 채팅방 상세 화면에 작가 프로필 이미지 연동
- FragmentChatDetail → ChatRoomScreen → CommissionInfoCard 데이터 전달 구조 수정
- Intent/Bundle를 통해 requestId, thumbnailUrl, artistProfileImage 값 전달 추가

🔍 작업 목적

- 채팅방 상세 화면에서 커미션 정보를 직관적으로 확인 가능하도록 개선
- API에서 받은 데이터를 UI에 반영해 사용자 경험(UX) 향상

✅ 체크리스트

- [ ]  코드 리뷰 완료
- [x]  빌드 성공
- [x]  포맷 검사 완료
- [ ]  실제 API 응답 값으로 이미지 정상 출력 확인(썸네일 이밎 추후 개선_예정)
