### PR TITLE
fix:CommissionId에 따른  폼 응답 형식 수정

### DIFF
--- a/app/src/main/java/com/example/commit/activity/author/AuthorProfileActivity.kt
+++ b/app/src/main/java/com/example/commit/activity/author/AuthorProfileActivity.kt
@@ -497,7 +497,7 @@ class AuthorProfileActivity : AppCompatActivity() {
         val api = RetrofitObject.getRetrofitService(this)
         val request = RetrofitClient.CreateChatroomRequest(
             artistId = artistId,
-            commissionId = commissionId
+            commissionId = commissionId.toString()
         )
 
         api.createChatroom(request).enqueue(object :

--- a/app/src/main/java/com/example/commit/connection/RetrofitAPI.kt
+++ b/app/src/main/java/com/example/commit/connection/RetrofitAPI.kt
@@ -91,13 +91,13 @@ interface RetrofitAPI {
     // [커미션 상세보기(PostScreen)]
     @GET("/api/commissions/{commissionId}")
     fun getCommissionDetail(
-        @Path("commissionId") commissionId: Int
+        @Path("commissionId") commissionId: String
     ): Call<CommissionDetailResponse>
 
     // [제출된 신청서 보기] (동일 path이지만 다른 DTO 사용)
     @GET("/api/commissions/{commissionId}/forms")
     fun getSubmittedCommissionForm(
-        @Path("commissionId") commissionId: Int
+        @Path("commissionId") commissionId: String
     ): Call<RetrofitClient.ApiResponse<RetrofitClient.SubmittedFormData>>
 
     // [신청함 목록]
@@ -177,7 +177,7 @@ interface RetrofitAPI {
      //커미션 작가 정보 조회
     @GET("/api/commissions/{commissionId}/artist")
     fun getCommissionArtist(
-        @Path("commissionId") commissionId: Int,
+        @Path("commissionId") commissionId: String,
         @Query("page") page: Int = 1,
         @Query("limit") limit: Int = 10
     ): Call<ApiResponse<CommissionArtistResponse>>

--- a/app/src/main/java/com/example/commit/connection/RetrofitClient.kt
+++ b/app/src/main/java/com/example/commit/connection/RetrofitClient.kt
@@ -340,7 +340,7 @@ class RetrofitClient {
         @SerializedName("artistId")
         val artistId: Int,
         @SerializedName("commissionId")
-        val commissionId: Int
+        val commissionId: String
     )
 
     // 채팅방 생성 응답 DTO

--- a/app/src/main/java/com/example/commit/connection/RetrofitObject.kt
+++ b/app/src/main/java/com/example/commit/connection/RetrofitObject.kt
@@ -3,6 +3,7 @@ package com.example.commit.connection
 import android.content.Context
 import android.util.Log
 import okhttp3.Interceptor
+import okhttp3.logging.HttpLoggingInterceptor
 import okhttp3.OkHttpClient
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
@@ -29,10 +30,15 @@ object RetrofitObject {
             chain.proceed(requestBuilder.build())
         }
 
+        val logging = HttpLoggingInterceptor { message ->
+            Log.d("OkHttp", message)
+        }.apply { level = HttpLoggingInterceptor.Level.BODY }
+
         val client = OkHttpClient.Builder()
             .readTimeout(30, TimeUnit.SECONDS)
             .writeTimeout(30, TimeUnit.SECONDS)
             .addInterceptor(authInterceptor) // 토큰 자동 추가
+            .addInterceptor(logging)
             .build()
 
         val retrofit = Retrofit.Builder()

--- a/app/src/main/java/com/example/commit/data/model/RequestDetailResponse.kt
+++ b/app/src/main/java/com/example/commit/data/model/RequestDetailResponse.kt
@@ -29,7 +29,8 @@ data class FormItem(
 
 @Parcelize
 data class OptionItem(
-    val label: String
+    val label: String,
+    val value: String = label
 ) : Parcelable
 
 @Parcelize

--- a/app/src/main/java/com/example/commit/fragment/FragmentChat.kt
+++ b/app/src/main/java/com/example/commit/fragment/FragmentChat.kt
@@ -168,6 +168,11 @@ class FragmentChat : Fragment() {
         val prefs = requireContext().getSharedPreferences("auth", Context.MODE_PRIVATE)
         val token = prefs.getString("accessToken", "토큰 없음")
         Log.d("FragmentChat", "현재 저장된 토큰 길이: ${token?.length ?: 0}")
+        try {
+            val userId = com.example.commit.connection.RetrofitObject.getCurrentUserId(requireContext())
+            Log.d("FragmentChat", "JWT userId: ${userId ?: "null"}")
+        } catch (_: Exception) {
+        }
 
         Log.d("ChatAPI", "채팅방 목록 조회 시작")
         val api = RetrofitObject.getRetrofitService(requireContext())
@@ -216,7 +221,7 @@ class FragmentChat : Fragment() {
         val api = RetrofitObject.getRetrofitService(requireContext())
         val request = RetrofitClient.CreateChatroomRequest(
             artistId = artistId,
-            commissionId = commissionId
+            commissionId = commissionId.toString()
         )
 
         api.createChatroom(request).enqueue(object :

--- a/app/src/main/java/com/example/commit/fragment/FragmentHome.kt
+++ b/app/src/main/java/com/example/commit/fragment/FragmentHome.kt
@@ -366,7 +366,7 @@ class FragmentHome : Fragment() {
 
         val request = RetrofitClient.CreateChatroomRequest(
             artistId = artistId,
-            commissionId = commissionId
+            commissionId = commissionId.toString()
         )
 
         api.createChatroom(request).enqueue(object :
@@ -389,7 +389,7 @@ class FragmentHome : Fragment() {
                 val chatroomIdInt = data.id.toIntOrNull()
 
                 // ① 작가 닉네임 조회
-                api.getCommissionArtist(commissionId).enqueue(object :
+                api.getCommissionArtist(commissionId.toString()).enqueue(object :
                     Callback<com.example.commit.connection.dto.ApiResponse<com.example.commit.connection.dto.CommissionArtistResponse>> {
                     override fun onResponse(
                         call: Call<com.example.commit.connection.dto.ApiResponse<com.example.commit.connection.dto.CommissionArtistResponse>>,

--- a/app/src/main/java/com/example/commit/fragment/FragmentPostChatDetail.kt
+++ b/app/src/main/java/com/example/commit/fragment/FragmentPostChatDetail.kt
@@ -146,7 +146,7 @@ class FragmentPostChatDetail : Fragment() {
         
         Log.d("FragmentPostChatDetail", "제출된 신청서 조회 시작 - commissionId: $commissionId")
         
-        api.getSubmittedCommissionForm(commissionId).enqueue(object : Callback<RetrofitClient.ApiResponse<RetrofitClient.SubmittedFormData>> {
+        api.getSubmittedCommissionForm(commissionId.toString()).enqueue(object : Callback<RetrofitClient.ApiResponse<RetrofitClient.SubmittedFormData>> {
             override fun onResponse(
                 call: Call<RetrofitClient.ApiResponse<RetrofitClient.SubmittedFormData>>,
                 response: Response<RetrofitClient.ApiResponse<RetrofitClient.SubmittedFormData>>

--- a/app/src/main/java/com/example/commit/ui/FormCheck/FormCheckSection.kt
+++ b/app/src/main/java/com/example/commit/ui/FormCheck/FormCheckSection.kt
@@ -113,7 +113,7 @@ fun FormCheckSection(
         formSchema.forEachIndexed { index, schemaItem ->
             val answer = formAnswer[schemaItem.label]
             val answerText = when (answer) {
-                is List<*> -> answer.joinToString(", ")
+                is List<*> -> answer.mapNotNull { it?.toString() }.joinToString(", ")
                 is String -> answer
                 else -> "응답 없음"
             }

--- a/app/src/main/java/com/example/commit/ui/post/FragmentPostScreen.kt
+++ b/app/src/main/java/com/example/commit/ui/post/FragmentPostScreen.kt
@@ -171,7 +171,7 @@ class FragmentPostScreen : Fragment() {
         val api = RetrofitObject.getRetrofitService(requireContext())
 
         // 1) 커미션 상세에서 artistId 획득
-        api.getCommissionDetail(commissionId).enqueue(object : Callback<CommissionDetailResponse> {
+        api.getCommissionDetail(commissionId.toString()).enqueue(object : Callback<CommissionDetailResponse> {
             override fun onResponse(
                 call: Call<CommissionDetailResponse>,
                 response: Response<CommissionDetailResponse>
@@ -193,10 +193,10 @@ class FragmentPostScreen : Fragment() {
                 }
 
                 // 2) 채팅방 생성 (JWT에서 userId 추출 → 바디는 artistId/commissionId만)
-                val req = RetrofitClient.CreateChatroomRequest(
-                    artistId = artistId,
-                    commissionId = commissionId
-                )
+                        val req = RetrofitClient.CreateChatroomRequest(
+            artistId = artistId,
+            commissionId = commissionId.toString()
+        )
                 api.createChatroom(req).enqueue(object :
                     Callback<RetrofitClient.ApiResponse<RetrofitClient.CreateChatroomResponse>> {
                     override fun onResponse(

--- a/app/src/main/java/com/example/commit/ui/request/form/CommissionOptionSection.kt
+++ b/app/src/main/java/com/example/commit/ui/request/form/CommissionOptionSection.kt
@@ -25,6 +25,11 @@ fun CommissionOptionSection(
     val primaryColor = Color(0xFF17D5C6)
     
     Log.d("FormDebug", "CommissionOptionSection 렌더링 - index: $index, title: $title, options: $options, selectedOption: $selectedOption")
+    
+    // selectedOption이 value인지 label인지 구분해서 비교하는 헬퍼 함수
+    fun isOptionSelected(selectedValue: String, optionLabel: String): Boolean {
+        return selectedValue == optionLabel
+    }
 
     CommissionSectionWrapper(
         index = index,
@@ -37,7 +42,7 @@ fun CommissionOptionSection(
                 modifier = Modifier.padding(vertical = 4.dp)
             ) {
                 RadioButton(
-                    selected = selectedOption == options[0],
+                    selected = isOptionSelected(selectedOption, options[0]),
                     onClick = { 
                         Log.d("FormDebug", "라디오 버튼 클릭됨 - $title: ${options[0]}")
                         onOptionSelected(options[0]) 
@@ -69,7 +74,7 @@ fun CommissionOptionSection(
                         verticalAlignment = Alignment.CenterVertically
                     ) {
                         RadioButton(
-                            selected = selectedOption == option,
+                            selected = isOptionSelected(selectedOption, option),
                             onClick = { 
                                 Log.d("FormDebug", "라디오 버튼 클릭됨 - $title: $option")
                                 onOptionSelected(option) 

--- a/app/src/main/java/com/example/commit/viewmodel/ArtistViewModel.kt
+++ b/app/src/main/java/com/example/commit/viewmodel/ArtistViewModel.kt
@@ -57,7 +57,7 @@ class ArtistViewModel : ViewModel() {
         inFlight?.cancel()
 
         val service = RetrofitObject.getRetrofitService(context)
-        val call = service.getCommissionArtist(commissionId, page, limit)
+        val call = service.getCommissionArtist(commissionId.toString(), page, limit)
         inFlight = call
 
         call.enqueue(object : Callback<ApiResponse<CommissionArtistResponse>> {

--- a/app/src/main/java/com/example/commit/viewmodel/PostViewModel.kt
+++ b/app/src/main/java/com/example/commit/viewmodel/PostViewModel.kt
@@ -34,7 +34,7 @@ class PostViewModel : ViewModel() {
 
     fun loadCommissionDetail(context: Context, id: Int) {
         val service = RetrofitObject.getRetrofitService(context)
-        service.getCommissionDetail(id)
+        service.getCommissionDetail(id.toString())
             .enqueue(object : retrofit2.Callback<com.example.commit.connection.dto.CommissionDetailResponse> {
                 override fun onResponse(
                     call: retrofit2.Call<com.example.commit.connection.dto.CommissionDetailResponse>,


### PR DESCRIPTION
## 📌 작업 내용
- CommissionFormScreen에서 id 타입 불일치(Number ↔ String) 오류 수정
- OptionItem 생성 시 String? → String 처리 로직 보강
- 기본 스키마와 API 스키마 모두 id 타입을 String으로 통일
- CommissionId에 따른 폼 형식 구현

## 🔍 작업 목적
- 런타임/컴파일 오류를 방지하고 안정적으로 폼 데이터를 파싱하기 위함
- API 응답 스키마와 앱 내부 데이터모델 간 불일치 해소

## ✅ 체크리스트
- [ ]  코드 리뷰 완료
- [x]  빌드 성공
- [ ]  포맷 검사 완료