### PR TITLE
feat: chatroom 썸네일 이미지 추가

### DIFF
--- a/app/src/main/java/com/example/commit/connection/RetrofitClient.kt
+++ b/app/src/main/java/com/example/commit/connection/RetrofitClient.kt
@@ -369,7 +369,7 @@ class RetrofitClient {
     // 채팅방 목록 DTO
     data class ChatroomItem(
         @SerializedName("request_id") val requestId: Int?,              // ★ 요청 id
-        @SerializedName("commission_thumbnail_url") val thumbnailUrl: String?, // ★ 썸네일
+        @SerializedName("commission_thumbnail") val thumbnailUrl: String?, // ★ 썸네일
         @SerializedName("chatroom_id")
         val chatroomId: String,
         @SerializedName("artist_id")

--- a/app/src/main/java/com/example/commit/fragment/FragmentPostChatDetail.kt
+++ b/app/src/main/java/com/example/commit/fragment/FragmentPostChatDetail.kt
@@ -76,6 +76,7 @@ class FragmentPostChatDetail : Fragment() {
                         authorName = authorName,
                         chatroomId = chatroomId,
                         chatViewModel = chatViewModel,
+                        commissionThumbnailUrl = arguments?.getString("thumbnailUrl"), // ★ 추가
                         onPayClick = {
                             if (isAdded && !isDetached) {
                                 parentFragmentManager.popBackStack()

--- a/app/src/main/java/com/example/commit/ui/chatroom/ChatRoomScreen.kt
+++ b/app/src/main/java/com/example/commit/ui/chatroom/ChatRoomScreen.kt
@@ -63,7 +63,8 @@ fun ChatRoomScreen(
 
         CommissionInfoCard(
             title = commissionTitle,
-            thumbnailImageUrl = commissionThumbnailUrl)
+            thumbnailImageUrl = commissionThumbnailUrl
+        )
 
         // 메시지 목록
         ChatMessageList(

--- a/app/src/main/java/com/example/commit/ui/chatroom/CommissionInfoCard.kt
+++ b/app/src/main/java/com/example/commit/ui/chatroom/CommissionInfoCard.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.Font
 import androidx.compose.ui.text.font.FontFamily
@@ -42,6 +43,7 @@ fun CommissionInfoCard(
     thumbnailImageUrl: String? = null
 ) {
     Column(modifier = Modifier.fillMaxWidth()) {
+        val hasThumb = !thumbnailImageUrl.isNullOrBlank()
 
         // 커미션 박스
         Row(
@@ -50,26 +52,31 @@ fun CommissionInfoCard(
                 .padding(top = 16.dp, start = 28.dp, end = 28.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
-            if (!thumbnailImageUrl.isNullOrBlank()) {
+            if (hasThumb) {
+                // ✅ URL 썸네일 (Coil)
                 AsyncImage(
-                    model = thumbnailImageUrl,
-                    contentDescription = "프로필 이미지",
+                    model = coil.request.ImageRequest.Builder(LocalContext.current)
+                        .data(thumbnailImageUrl)
+                        .crossfade(true)
+                        .build(),
+                    contentDescription = "커미션 썸네일",
                     contentScale = ContentScale.Crop,
+                    placeholder = painterResource(R.drawable.bg_thumbnail_rounded), // 로딩 중
+                    error = painterResource(R.drawable.bg_thumbnail_rounded),       // 실패 시
                     modifier = Modifier
                         .size(46.dp)
                         .clip(RoundedCornerShape(4.dp))
                 )
             } else {
-            // 썸네일
-            Image(
-                painter = painterResource(id = R.drawable.bg_thumbnail_rounded),
-                contentDescription = "썸네일 이미지",
-                modifier = Modifier
-                    .size(46.dp)
-                    .clip(RoundedCornerShape(4.dp))
-                    .background(Color.LightGray), // 썸네일 배경 (임시)
-                contentScale = ContentScale.Crop
-            )
+                // ✅ 로컬 기본 썸네일
+                Image(
+                    painter = painterResource(id = R.drawable.bg_thumbnail_rounded),
+                    contentDescription = "기본 썸네일",
+                    contentScale = ContentScale.Crop,
+                    modifier = Modifier
+                        .size(46.dp)
+                        .clip(RoundedCornerShape(4.dp))
+                )
             }
 
             Spacer(modifier = Modifier.width(12.dp))
@@ -123,8 +130,10 @@ fun CommissionInfoCard(
 fun PreviewCommissionInfoCard() {
     CommissionInfoCard(
         title = "낙서 타입 커미션",
+        thumbnailImageUrl = "https://picsum.photos/seed/commit/200/200",
         onSeePostClick = { println("글보기 버튼 클릭됨") }
     )
 }
+
 
 


### PR DESCRIPTION
## 📌 작업 내용

- 썸네일 파이프라인 정비
  - DTO 수정: ChatroomItem.thumbnailUrl의 @SerializedName("commission_thumbnail_url") → **@SerializedName("commission_thumbnail")**로 변경.
- 목록 → 상세 이동 시 번들에 putString("thumbnailUrl", item.thumbnailUrl) 전달.
  - FragmentPostChatDetail에서 **같은 키("thumbnailUrl")**로 꺼내 ChatRoomScreen(commissionThumbnailUrl = …)에 전달.
- CommissionInfoCard의 AsyncImage에 placeholder/error + onError 로그 추가로 로딩/실패 가시성 개선.

## 🔍 작업 목적
- 썸네일 이미지 노출로 사용자 경험 향상

## ✅ 체크리스트
- [ ] 코드 리뷰 완료
- [ ] 빌드 성공
- [ ] 포맷 검사 완료
